### PR TITLE
Fix inverted pointer cursors when triggered `file` by cards

### DIFF
--- a/gizmos.js
+++ b/gizmos.js
@@ -411,6 +411,7 @@ function (dojo, declare) {
 						this.addActionButton( 'button_file', _('File'), 'fileSelectedCard' );
 						this.addActionButton( 'button_cancel', _('Cancel'), 'cancel' );
 						dojo.addClass( 'button_file', 'disabled');
+						dojo.query('.selectable').removeClass('selectable');
 						dojo.query('.row_card').addClass('selectable');
 						break;					
 					default:

--- a/gizmos.js
+++ b/gizmos.js
@@ -411,6 +411,7 @@ function (dojo, declare) {
 						this.addActionButton( 'button_file', _('File'), 'fileSelectedCard' );
 						this.addActionButton( 'button_cancel', _('Cancel'), 'cancel' );
 						dojo.addClass( 'button_file', 'disabled');
+						dojo.query('.row_card').addClass('selectable');
 						break;					
 					default:
 						break;


### PR DESCRIPTION
Thanks for your implementation and sharing it with us like this. 🎲 

When I was playing Gizmos in BGA, executing `card_326` correctly triggered the `file` action. But it does not show the cursor pointer even when I mouse over in any card row in the "Display Area".
On the other hand, the current player's cards and the tokens displayed in the pool are still selectable.

I have no experience with PHP coding and have never used the BGA SDK, but I guess changes like this might be needed.
If this is wrong or not enough, please reject or comment on this PR.

* <img width="380" alt="スクリーンショット 2023-06-11 051214" src="https://github.com/Fletcheese/gizmos/assets/1180335/b4b8c305-e16b-4251-99eb-f923b5a1bc48">
* <img width="330" alt="スクリーンショット 2023-06-11 051259" src="https://github.com/Fletcheese/gizmos/assets/1180335/171a2a15-04e5-4518-8754-aac3cd8fee54">
* <img width="444" alt="スクリーンショット 2023-06-11 051233" src="https://github.com/Fletcheese/gizmos/assets/1180335/18907cc7-7e30-46a3-8f74-b0e6391b68df">

https://github.com/Fletcheese/gizmos/blob/bc8e07a68762388499ceaf3044824f75ec7254ec/material.inc.php#L3745-L3756

(Sorry for uploading picture of non-English, I played the session with Japanese UI)